### PR TITLE
chore: introduce definitions for customer variables

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,12 +13,25 @@ import {
   getLoaderVersion,
 } from './utils'
 import { getDomainFromHostname } from './domain'
+import { CustomerVariables } from './utils/customer-variables/customer-variables'
 
 export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFrontResultResponse> => {
   const request = event.Records[0].cf.request
 
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const customerVariables = new CustomerVariables([
+    // SecretManagerProvider(request)
+    // HeaderProvider(request)
+  ])
+
   const domain = getDomainFromHostname(getHost(request))
 
+  /**
+   * Later, we can move getAgentUri, getResultUri functions to separate file from headers.ts, and pass to them customerVariables rather than request.
+   * There they can call the CustomerVariables to get required values, e.g:
+   *  customerVariables.getVariable(CustomerVariableType.AgentDownloadPath)
+   * */
   if (request.uri === getAgentUri(request)) {
     const endpoint = `/v3/${getApiKey(request)}/loader_v${getLoaderVersion(request)}.js`
     return downloadAgent({

--- a/src/utils/customer-variables/customer-variables.ts
+++ b/src/utils/customer-variables/customer-variables.ts
@@ -1,0 +1,42 @@
+import { CustomerVariableProvider, CustomerVariableType } from './types'
+import { getDefaultCustomerVariable } from './defaults'
+
+/**
+ * Allows access to customer defined variables using multiple providers.
+ * Variables will be resolved in order in which providers are set.
+ * */
+export class CustomerVariables {
+  constructor(private readonly providers: CustomerVariableProvider[]) {}
+
+  /**
+   * Attempts to resolve customer variable using providers.
+   * If no provider can resolve the variable, the default value is returned.
+   * */
+  async getVariable(variable: CustomerVariableType) {
+    const providerResult = await this.getValueFromProviders(variable)
+
+    if (providerResult) {
+      return providerResult
+    }
+
+    const defaultValue = getDefaultCustomerVariable(variable)
+
+    console.info(`Resolved customer variable ${variable} with default value ${defaultValue}`)
+
+    return defaultValue
+  }
+
+  private async getValueFromProviders(variable: CustomerVariableType) {
+    for (const provider of this.providers) {
+      const result = await provider.getVariable(variable)
+
+      if (result) {
+        console.info(`Resolved customer variable ${variable} with provider ${provider.name}`)
+
+        return result
+      }
+    }
+
+    return null
+  }
+}

--- a/src/utils/customer-variables/defaults.ts
+++ b/src/utils/customer-variables/defaults.ts
@@ -1,0 +1,12 @@
+import { CustomerVariableValue, CustomerVariableType } from './types'
+
+const defaultCustomerVariables: Record<CustomerVariableType, CustomerVariableValue> = {
+  [CustomerVariableType.BehaviourPath]: 'fpjs',
+  [CustomerVariableType.GetResultPath]: 'resultId',
+  [CustomerVariableType.PreSharedSecret]: null,
+  [CustomerVariableType.AgentDownloadPath]: 'agent',
+}
+
+export function getDefaultCustomerVariable(variable: CustomerVariableType): CustomerVariableValue {
+  return defaultCustomerVariables[variable]
+}

--- a/src/utils/customer-variables/types.ts
+++ b/src/utils/customer-variables/types.ts
@@ -1,0 +1,14 @@
+export enum CustomerVariableType {
+  BehaviourPath = 'fpjs_behavior_path',
+  GetResultPath = 'fpjs_get_result_path',
+  PreSharedSecret = 'fpjs_pre_shared_secret',
+  AgentDownloadPath = 'fpjs_agent_download_path',
+}
+
+export type CustomerVariableValue = string | null
+
+export interface CustomerVariableProvider {
+  readonly name: string
+
+  getVariable: (variable: CustomerVariableType) => Promise<string | null>
+}


### PR DESCRIPTION
The first part of introducing support for AWS Secret Manager.

It introduces `CustomerVariables` which will be used to resolve any variables customer defines. It supports passing providers that will attempt to resolve a given variable, and if it fails it will move to the next one. If no provider will resolve the given variable, we'll fallback to the default value.

The order for resolving customer variables will be: AWS Secret Manager -> Request Headers -> default values (defined in `src/utils/customer-variables/defaults.ts` ) 