### PR TITLE
fix: rewrite headers filtering implementation

### DIFF
--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -31,6 +31,7 @@ const BLACKLISTED_HEADERS = new Set([
   'x-cache',
   'x-forwarded-proto',
   'x-real-ip',
+  'strict-transport-security',
 ])
 
 const BLACKLISTED_HEADERS_PREFIXES = ['x-edge-', 'x-amz-cf-']

--- a/test/utils/headers.test.ts
+++ b/test/utils/headers.test.ts
@@ -151,6 +151,12 @@ describe('filterRequestHeaders', () => {
             key: 'x-edge-qqq',
             value: 'some value'
           }
+        ],
+        'strict-transport-security': [
+          {
+            key: 'strict-transport-security',
+            value: 'max-age=600'
+          }
         ]
       },
     }
@@ -167,7 +173,8 @@ describe('filterRequestHeaders', () => {
     expect(headers.hasOwnProperty('x-amzn-cf-id')).toBe(false)
     expect(headers.hasOwnProperty('x-amz-cf-id')).toBe(false)
     expect(headers.hasOwnProperty('x-amz-cf-yyy')).toBe(false)
-    expect(headers.hasOwnProperty('x-edge-qqq')).toBe(false)    
+    expect(headers.hasOwnProperty('x-edge-qqq')).toBe(false)
+    expect(headers.hasOwnProperty('strict-transport-security')).toBe(false)
   })
 })
 
@@ -190,7 +197,8 @@ describe('updateResponseHeaders', () => {
       'x-amz-cf-pop': 'dsjfdsa',
       'x-amzn-cf-id': 'zxcvbn',
       'x-amz-cf-xxx': 'cxc',
-      'x-edge-xxx': 'ery8u'
+      'x-edge-xxx': 'ery8u',
+      'strict-transport-security': 'max-age=1000'
     }
     const cfHeaders: CloudFrontHeaders = updateResponseHeaders(headers, 'fpjs.sh')
     expect(cfHeaders.hasOwnProperty('custom-header-1')).toBe(true)
@@ -202,6 +210,7 @@ describe('updateResponseHeaders', () => {
     expect(cfHeaders.hasOwnProperty('x-edge-xxx')).toBe(false)
     expect(cfHeaders['cache-control'][0].value).toBe('public, max-age=3600, s-maxage=60')
     expect(cfHeaders['set-cookie'][0].value).toBe('_iidf; HttpOnly; Domain=fpjs.sh')
+    expect(cfHeaders.hasOwnProperty('strict-transport-security')).toBe(false)
   })
 
   test('update cache policy', () => {


### PR DESCRIPTION
* Remove whitelist for response headers
* Add checks for blacklisted and read-only headers in response
* Custom headers that not in Lambda@Edge blacklist now are allowed to pass to client