### PR TITLE
fix(cloudformation): update regex to validate secret names

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Fingerprint Pro Lambda@Edge function for CloudFront integration
 Parameters:
   SecretName:
-    AllowedPattern: ^([a-zA-Z0-9\-\:])+$
+    AllowedPattern: ^([a-zA-Z0-9\/_+=.@\-])+$
     Description: AWS Secret Name
     Type: String
   SecretRegion:


### PR DESCRIPTION
As per AWS documentation:

> The secret name can contain ASCII letters, numbers, and the following characters: /_+=.@-