### PR TITLE
dependabot: prevent regular updates INTER-169

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
prevent regular updates and only allow security updates on develop branch