### PR TITLE
Attach domain alias and certificate reference to CloudFront distribution

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -35,7 +35,7 @@ Parameters:
     Description: FPJS_PRE_SHARED_SECRET value
     Type: String
   DomainName:
-    Description: Domain name to attach to CloudFront distribution
+    Description: Domain names to attach to CloudFront distribution. Several domains names should be separated by plus sign (domain1.com+domain2.com)
     Default: ""
     Type: String
   ACMCertificateARN:
@@ -159,7 +159,7 @@ Resources:
         Aliases:
           !If
           - AttachDomainToCloudFront
-          - !Ref DomainName
+          - !Split ['+', !Ref DomainName]
           - !Ref AWS::NoValue
         ViewerCertificate:
           !If


### PR DESCRIPTION
Scope of changes:
* Added new parameters `DomainName` to set a domain, and `ACMCertificateARN` to set a reference to SSL certificate from AWS Certificates Manager
* If it's configured to create a new CloudFront distribution and attach a domain name, given information will be attached to CloudFront distribution
Condition:
1. `DistributionId` is empty to create a new CloudFront distribution
2. `DomainName` and `ACMCertificateARN` are not empty to attach the given values.
* DNS entry should be created manually by the user
* Multiple domain names could be set via plus sign (domain1.com+domain2.com)