### PR TITLE
Add nonce-based csp to style

### DIFF
--- a/proxy/app.ts
+++ b/proxy/app.ts
@@ -13,6 +13,7 @@ import {
   getLoaderVersion,
   setLogLevel,
   createRoute,
+  generateRandom,
 } from './utils'
 import { CustomerVariables } from './utils/customer-variables/customer-variables'
 import { HeaderCustomerVariables } from './utils/customer-variables/header-customer-variables'
@@ -112,7 +113,7 @@ function handleStatusPage(
   _: CloudFrontRequest,
   customerVariables: CustomerVariables
 ): Promise<CloudFrontResultResponse> {
-  return handleStatus(customerVariables)
+  return handleStatus(customerVariables, generateRandom())
 }
 
 export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFrontResultResponse> => {

--- a/proxy/test/handlers/__snapshots__/handleStatus.test.ts.snap
+++ b/proxy/test/handlers/__snapshots__/handleStatus.test.ts.snap
@@ -39,6 +39,7 @@ exports[`Get status info returns correct response with empty non obfuscated vari
       "value": "api.fpjs.io",
     },
   ],
+  "styleNonce": "hardcodedStyleNonce",
   "version": "__lambda_func_version__",
 }
 `;
@@ -82,6 +83,7 @@ exports[`Get status info returns correct response with empty pre shared secret 1
       "value": "api.fpjs.io",
     },
   ],
+  "styleNonce": "hardcodedStyleNonce",
   "version": "__lambda_func_version__",
 }
 `;
@@ -125,6 +127,7 @@ exports[`Get status info returns correct status info 1`] = `
       "value": "api.fpjs.io",
     },
   ],
+  "styleNonce": "hardcodedStyleNonce",
   "version": "__lambda_func_version__",
 }
 `;
@@ -134,7 +137,7 @@ exports[`Handle status returns correct status info in html if all variables are 
       <head>
         <title>CloudFront integration status</title>
         <meta charset="utf-8">
-        <style>
+        <style nonce='hardcodedStyleNonce'>
           body, .env-info {
             display: flex;
           }
@@ -171,7 +174,7 @@ exports[`Handle status returns correct status info in html if some variables are
       <head>
         <title>CloudFront integration status</title>
         <meta charset="utf-8">
-        <style>
+        <style nonce='hardcodedStyleNonce'>
           body, .env-info {
             display: flex;
           }
@@ -211,7 +214,7 @@ exports[`Handle status returns correct status info in html if some variables are
       <head>
         <title>CloudFront integration status</title>
         <meta charset="utf-8">
-        <style>
+        <style nonce='hardcodedStyleNonce'>
           body, .env-info {
             display: flex;
           }

--- a/proxy/test/handlers/handleStatus.test.ts
+++ b/proxy/test/handlers/handleStatus.test.ts
@@ -2,14 +2,22 @@ import { getInMemoryCustomerVariables } from '../utils/customer-variables/in-mem
 import { CustomerVariableType } from '../../utils/customer-variables/types'
 import { getStatusInfo, handleStatus } from '../../handlers/handleStatus'
 
+const styleNonce = 'hardcodedStyleNonce'
+
 describe('Handle status', () => {
   it('returns correct status info in html if all variables are set', async () => {
     const { customerVariables } = getInMemoryCustomerVariables()
 
-    const result = await handleStatus(customerVariables)
+    const result = await handleStatus(customerVariables, styleNonce)
 
     expect(result.headers).toEqual({
       'content-type': [{ key: 'Content-Type', value: 'text/html' }],
+      'content-security-policy': [
+        {
+          key: 'Content-Security-Policy',
+          value: `default-src 'none'; img-src https://fingerprint.com; style-src 'nonce-${styleNonce}'`,
+        },
+      ],
     })
 
     expect(result.body).toMatchSnapshot()
@@ -22,10 +30,16 @@ describe('Handle status', () => {
     variables.fpjs_agent_download_path = null
     variables.fpjs_get_result_path = null
 
-    const result = await handleStatus(customerVariables)
+    const result = await handleStatus(customerVariables, styleNonce)
 
     expect(result.headers).toEqual({
       'content-type': [{ key: 'Content-Type', value: 'text/html' }],
+      'content-security-policy': [
+        {
+          key: 'Content-Security-Policy',
+          value: `default-src 'none'; img-src https://fingerprint.com; style-src 'nonce-${styleNonce}'`,
+        },
+      ],
     })
 
     expect(result.body).toMatchSnapshot()
@@ -36,10 +50,16 @@ describe('Handle status', () => {
 
     variables.fpjs_pre_shared_secret = null
 
-    const result = await handleStatus(customerVariables)
+    const result = await handleStatus(customerVariables, styleNonce)
 
     expect(result.headers).toEqual({
       'content-type': [{ key: 'Content-Type', value: 'text/html' }],
+      'content-security-policy': [
+        {
+          key: 'Content-Security-Policy',
+          value: `default-src 'none'; img-src https://fingerprint.com; style-src 'nonce-${styleNonce}'`,
+        },
+      ],
     })
 
     expect(result.body).toMatchSnapshot()
@@ -50,7 +70,7 @@ describe('Get status info', () => {
   it('returns correct status info', async () => {
     const { customerVariables } = getInMemoryCustomerVariables()
 
-    const result = await getStatusInfo(customerVariables)
+    const result = await getStatusInfo(customerVariables, styleNonce)
 
     expect(result).toMatchSnapshot()
   })
@@ -59,7 +79,7 @@ describe('Get status info', () => {
     const { customerVariables, variables } = getInMemoryCustomerVariables()
     variables[CustomerVariableType.PreSharedSecret] = null
 
-    const result = await getStatusInfo(customerVariables)
+    const result = await getStatusInfo(customerVariables, styleNonce)
 
     expect(result).toMatchSnapshot()
   })
@@ -67,7 +87,7 @@ describe('Get status info', () => {
   it('returns correct response with empty non obfuscated variable', async () => {
     const { customerVariables } = getInMemoryCustomerVariables()
 
-    const result = await getStatusInfo(customerVariables)
+    const result = await getStatusInfo(customerVariables, styleNonce)
 
     expect(result).toMatchSnapshot()
   })

--- a/proxy/utils/index.ts
+++ b/proxy/utils/index.ts
@@ -20,6 +20,7 @@ import {
   addEndingTrailingSlashToRoute,
 } from './routing'
 import { setLogLevel } from './log'
+import { generateRandom } from './string'
 
 export {
   getAgentUri,
@@ -43,4 +44,5 @@ export {
   addPathnameMatchBeforeRoute,
   addEndingTrailingSlashToRoute,
   setLogLevel,
+  generateRandom,
 }

--- a/proxy/utils/string.ts
+++ b/proxy/utils/string.ts
@@ -1,0 +1,9 @@
+export function generateRandom() {
+  let result = ''
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const indices = crypto.getRandomValues(new Uint8Array(24))
+  for (const index of indices) {
+    result += characters[index % characters.length]
+  }
+  return btoa(result)
+}


### PR DESCRIPTION
Implemented `generateRandom` string utility function to create random strings. Updated `handleStatus` to accept a `styleNonce` parameter and added CSP headers to include `style-src` nonce. This decision has been made because of easy testing. Modified `renderHtml` in `handleStatus` to include the `nonce` attribute in the `<style>` tag. Fixed snapshot tests to accept the new `styleNonce` property.