### PR TITLE
Remove external config to bundle AWS deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "rollup": "^4.44.0",
     "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-license": "^3.6.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
     "ts-jest": "^29.4.0",
     "tslib": "^2.8.1",
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       rollup-plugin-license:
         specifier: ^3.6.0
         version: 3.6.0(picomatch@4.0.2)(rollup@4.44.0)
-      rollup-plugin-peer-deps-external:
-        specifier: ^2.2.4
-        version: 2.2.4(rollup@4.44.0)
       ts-jest:
         specifier: ^29.4.0
         version: 29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.0.1)(babel-jest@30.0.2(@babel/core@7.27.4))(jest-util@30.0.2)(jest@29.7.0(@types/node@20.19.1))(typescript@5.8.3)
@@ -898,9 +895,6 @@ packages:
 
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -2187,14 +2181,6 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fdir@6.4.4:
-    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
@@ -2913,10 +2899,6 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
-  magic-string@0.30.7:
-    resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
-    engines: {node: '>=12'}
-
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -3304,11 +3286,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
-
-  rollup-plugin-peer-deps-external@2.2.4:
-    resolution: {integrity: sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==}
-    peerDependencies:
-      rollup: '*'
 
   rollup@4.44.0:
     resolution: {integrity: sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==}
@@ -5149,8 +5126,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
     optional: true
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
@@ -6630,10 +6605,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.4.4(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
-
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
@@ -7603,10 +7574,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  magic-string@0.30.7:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.2
@@ -7940,9 +7907,9 @@ snapshots:
   rollup-plugin-license@3.6.0(picomatch@4.0.2)(rollup@4.44.0):
     dependencies:
       commenting: 1.1.0
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.2)
       lodash: 4.17.21
-      magic-string: 0.30.7
+      magic-string: 0.30.17
       moment: 2.30.1
       package-name-regex: 2.0.6
       rollup: 4.44.0
@@ -7950,10 +7917,6 @@ snapshots:
       spdx-satisfies: 5.0.1
     transitivePeerDependencies:
       - picomatch
-
-  rollup-plugin-peer-deps-external@2.2.4(rollup@4.44.0):
-    dependencies:
-      rollup: 4.44.0
 
   rollup@4.44.0:
     dependencies:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import typescript from '@rollup/plugin-typescript'
 import jsonPlugin from '@rollup/plugin-json'
-import external from 'rollup-plugin-peer-deps-external'
 import licensePlugin from 'rollup-plugin-license'
 import { dts } from 'rollup-plugin-dts'
 import replace from '@rollup/plugin-replace'
@@ -12,7 +11,6 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-const { dependencies } = require('./package.json')
 const outputDirectory = 'dist'
 
 function getEnv(key, defaultValue) {
@@ -47,11 +45,9 @@ function makeConfig(entryFile, artifactName) {
    * */
   const commonInput = {
     input: entryFile,
-    external: Object.keys(dependencies),
     plugins: [
       jsonPlugin(),
       typescript(),
-      external(),
       nodeResolve({ preferBuiltins: false }),
       commonjs(),
       replace({


### PR DESCRIPTION
This PR updates the Rollup configuration to bundle all required AWS SDK dependencies (`@aws-sdk/*`) directly into the CloudFront Lambda file.

## 🔧 Changes:
- Removed `rollup-plugin-peer-deps-external`
- Ensured SDK dependencies are no longer treated as external

## ❓ Why:
To avoid relying on AWS's runtime-provided SDK versions and for more stable behavior.

> ⚠️  Final artifact size is expected to increase (lambda: **~30K** -> **~524K**, mgmt: **~22K** -> **~848K**), which is acceptable.

Tested with an example subscription and deployment, confirmed Lambda is working. Still testing mgmt.

---

Related Task: INTER-1229