### PR TITLE
Fix unicode corruption in agent downloading endpoint

### DIFF
--- a/proxy/handlers/handleAgentDowloading.ts
+++ b/proxy/handlers/handleAgentDowloading.ts
@@ -10,7 +10,7 @@ function copySearchParams(oldSearchString: string, newURL: URL): void {
 
 export function downloadAgent(options: AgentOptions): Promise<CloudFrontResultResponse> {
   return new Promise((resolve) => {
-    const data: any[] = []
+    const data: Buffer[] = []
 
     const url = new URL(`https://${options.fpCdnUrl}`)
     url.pathname = getEndpoint(options.apiKey, options.version, options.loaderVersion)
@@ -26,14 +26,7 @@ export function downloadAgent(options: AgentOptions): Promise<CloudFrontResultRe
         headers: options.headers,
       },
       (response) => {
-        let binary = false
-        if (response.headers['content-encoding']) {
-          binary = true
-        }
-
-        response.setEncoding(binary ? 'binary' : 'utf8')
-
-        response.on('data', (chunk) => data.push(Buffer.from(chunk, 'binary')))
+        response.on('data', (chunk) => data.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8')))
 
         response.on('end', () => {
           const body = Buffer.concat(data)


### PR DESCRIPTION
When agent responses containing non-ASCII characters were sent, these characters were getting corrupted on the way through the proxy. We were decoding the body into a JS string and then re-encoding it as `binary`, which breaks UTF-8.

## ❓ What Changed?

- Removed `binary`/`utf-8` toggle because it inferred from `content-encoding` header.
- Added received body chunks as-is to the body accumulator.
- **Extra:** typed the body accumulator as `Buffer[]` (from `any[]`).

## ⚙️ How This Works?

Keeping everything as raw buffers avoids issues and problems with string encodings. No assumptions about `content-encoding`. Compressed and uncompressed bodies are preserved byte by byte.

## 🧑‍🔬 How To Test?

### 1. Smoke

Build the new CloudFront worker from this branch and deploy it to your AWS environment. Try to use the agent downloading with a basic client. This test will ensure everything works fine (no breaking).

### 2. Use Mock Server

Use [mock server](https://github.com/fingerprintjs/dx-team-mock-for-proxy-integrations-e2e-tests) and run `agent response body integrity protected with 200 status code` test with a CloudFront proxy integration (which points to your mock server). This test will ensure the new changes fix potential Unicode problems.

Shareable mock server form value (only test selected, empty fields):

```
eyJpbnRlZ3JhdGlvblVybCI6IiIsImluZ3Jlc3NQYXRoIjoiIiwiY2RuUGF0aCI6IiIsInRyYWZmaWNOYW1lIjoiIiwiaW50ZWdyYXRpb25WZXJzaW9uIjoiIiwidGVzdHNGaWx0ZXIiOlsiYWdlbnQgcmVzcG9uc2UgYm9keSBpbnRlZ3JpdHkgcHJvdGVjdGVkIHdpdGggMjAwIHN0YXR1cyBjb2RlIl19
```

## ✨ Potential Improvements

- Don't use `Buffer.isBuffer` and directly push chunks to the accumulator body. (`response.on('data', (chunk) => data.push(chunk))`)
- We can drop `content-length` from forwarded headers and let CloudFront handle the calculation.
- We can add a new mock server e2e test cases for `gzip/br` compression.
- Compressed/uncompressed test case content-length assertions.